### PR TITLE
Automated testing: Run flake8 tests on Circle CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,40 @@
+version: 2.0
+
+my-steps: &steps
+  - checkout
+  - run: sudo pip install flake8
+  - run: python --version ; pip --version ; pwd ; ls
+  # stop the build if there are Python syntax errors or undefined names
+  - run: flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+  # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide      
+  - run: flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+
+jobs:
+  Python_3.4:
+    docker:
+      - image: circleci/python:3.4
+    steps: *steps
+
+  Python_3.5:
+    docker:
+      - image: circleci/python:3.5
+    steps: *steps
+
+  Python_3.6:
+    docker:
+      - image: circleci/python:3.6
+    steps: *steps
+
+  Python_3.7:
+    docker:
+      - image: circleci/python:3.7
+    steps: *steps
+
+workflows:
+  version: 2
+  build:
+    jobs:
+      #- Python_3.4
+      #- Python_3.5
+      #- Python_3.6
+      - Python_3.7


### PR DESCRIPTION
Circle CI will automatically run [flake8](http://flake8.pycqa.org) tests to find Python syntax errors and undefined names.  For open source projects like this one, the Circle CI __service is free but it must be turned on__ at https://circleci.com/signup  Other alternative Continuous Integration services such as Travis CI, Appveyor, etc. are available https://github.com/marketplace/category/continuous-integration

__E901,E999,F821,F822,F823__ are the "_showstopper_" flake8 issues that can halt the runtime with a SyntaxError, NameError, etc. Most other flake8 issues are merely "style violations" -- useful for readability but they do not effect runtime safety.

    F821: undefined name name
    F822: undefined name name in __all__
    F823: local variable name referenced before assignment
    E901: SyntaxError or IndentationError
    E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree