### PR TITLE
Listbox: in Update(), point to the new values.

### DIFF
--- a/PySimpleGUI.py
+++ b/PySimpleGUI.py
@@ -420,6 +420,7 @@ class Listbox(Element):
         for item in values:
             self.TKListbox.insert(tk.END, item)
         self.TKListbox.selection_set(0, 0)
+        self.Values = values
 
     def SetValue(self, values):
         for index, item in enumerate(self.Values):


### PR DESCRIPTION
I noticed when updating the values of a Listbox, that the selected values returned from form.ReadNonBlocking() where from the old array of values.