### PR TITLE
Update readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -477,7 +477,7 @@ Here is a quick-reference showing how the Popup calls look.
     sg.PopupOk('PopupOk')  - Shows OK button    
     sg.PopupYesNo('PopupYesNo')  - Shows Yes and No buttons    
     sg.PopupCancel('PopupCancel')  - Shows Cancelled button    
-    sg.PopupOkCancel('PopupOkCancel')  - Shows Ok and Cancel buttons    
+    sg.PopupOKCancel('PopupOKCancel')  - Shows OK and Cancel buttons
     sg.PopupError('PopupError')  - Shows red error button    
     sg.PopupTimed('PopupTimed')  - Automatically closes    
     sg.PopupAutoClose('PopupAutoClose')  - Same as PopupTimed    


### PR DESCRIPTION
.PopupOKCancel currently requires the K to be uppercase. Propose changing in documentation or aliasing. Only known to affect Readme.md at present.