### PR TITLE
Fix/workaround for path separators on Windows

### DIFF
--- a/PySimpleGUI.py
+++ b/PySimpleGUI.py
@@ -1316,6 +1316,8 @@ class Button(Element):
             folder_name = tk.filedialog.askdirectory(initialdir=self.InitialFolder)  # show the 'get folder' dialog box
             if folder_name != '':
                 try:
+                    if sys.platform == 'win32':
+                        folder_name = folder_name.replace("/", "\\")
                     strvar.set(folder_name)
                     self.TKStringVar.set(folder_name)
                 except:
@@ -1326,6 +1328,8 @@ class Button(Element):
             else:
                 file_name = tk.filedialog.askopenfilename(filetypes=filetypes, initialdir=self.InitialFolder)  # show the 'get file' dialog box
             if file_name != '':
+                if sys.platform == 'win32':
+                    file_name = file_name.replace("/", "\\")
                 strvar.set(file_name)
                 self.TKStringVar.set(file_name)
         elif self.BType == BUTTON_TYPE_COLOR_CHOOSER:
@@ -1340,6 +1344,8 @@ class Button(Element):
                 file_name = tk.filedialog.askopenfilenames(filetypes=filetypes, initialdir=self.InitialFolder)
             if file_name != '':
                 file_name = ';'.join(file_name)
+                if sys.platform == 'win32':
+                    file_name = file_name.replace("/", "\\")
                 strvar.set(file_name)
                 self.TKStringVar.set(file_name)
         elif self.BType == BUTTON_TYPE_SAVEAS_FILE:
@@ -1349,6 +1355,8 @@ class Button(Element):
                 file_name = tk.filedialog.asksaveasfilename(filetypes=filetypes,
                                                         initialdir=self.InitialFolder)  # show the 'get file' dialog box
             if file_name != '':
+                if sys.platform == 'win32':
+                    file_name = file_name.replace("/", "\\")
                 strvar.set(file_name)
                 self.TKStringVar.set(file_name)
         elif self.BType == BUTTON_TYPE_CLOSES_WIN:  # this is a return type button so GET RESULTS and destroy window


### PR DESCRIPTION
On Windows, file dialogues (FileBrowse, FilesBrowse, FolderBrowse, FileSaveAs) return paths with "/" as folder separators, instead of "\". This is a simple workaround.