### PR TITLE
[Qt] Fix: Show tray message without defining an icon

### DIFF
--- a/PySimpleGUIQt/PySimpleGUIQt.py
+++ b/PySimpleGUIQt/PySimpleGUIQt.py
@@ -2933,7 +2933,7 @@ class SystemTray:
         elif messageicon is not None:
             self.TrayIcon.showMessage(title, message, messageicon, time)
         else:
-            self.TrayIcon.showMessage(title, message, time)
+            self.TrayIcon.showMessage(title, message, QIcon(), time)
 
         self.LastMessage = message
         self.LastTitle = title


### PR DESCRIPTION
Calling self.TrayIcon.showMessage without an icon file gives this error (at least on Windows7 64bit / python3.7.1 64bit) 

TypeError: 'PySide2.QtWidgets.QSystemTrayIcon.showMessage' called with wrong argument types:
  PySide2.QtWidgets.QSystemTrayIcon.showMessage(str, str, int)
Supported signatures:
  PySide2.QtWidgets.QSystemTrayIcon.showMessage(unicode, unicode, PySide2.QtWidgets.QSystemTrayIcon.MessageIcon = QSystemTrayIcon.Information, int = 10000)
  PySide2.QtWidgets.QSystemTrayIcon.showMessage(unicode, unicode, PySide2.QtGui.QIcon, int = 10000)

Passing an empty QIcon() fixes the problem for me.